### PR TITLE
Add ability to configure keyring session key name

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,14 @@ role_arn = arn:aws:iam::<account-id>:role/<okta-role-name>
 # This profile uses the "integrations-auth" Okta app combined with secondary role assumption
 source_profile = integrations-auth
 role_arn = arn:aws:iam::<account-id>:role/<secondary-role-name>
+
+[profile testaccount]
+# This stores the Okta session in a separate item in the Keyring.
+# This is useful if the Okta session is used or modified by other applications
+# and needs to be isolated from other sessions. It is also useful for
+# development versions or multiple versions of awsokta running.
+okta_session_cookie_key = okta-session-cookie-test
+role_arn = arn:aws:iam::<account-id>:role/<okta-role-name>
 ```
 
 The configuration above means that you can use multiple Okta Apps at the same time and switch between them easily.

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ role_arn = arn:aws:iam::<account-id>:role/<secondary-role-name>
 # This stores the Okta session in a separate item in the Keyring.
 # This is useful if the Okta session is used or modified by other applications
 # and needs to be isolated from other sessions. It is also useful for
-# development versions or multiple versions of awsokta running.
+# development versions or multiple versions of aws-okta running.
 okta_session_cookie_key = okta-session-cookie-test
 role_arn = arn:aws:iam::<account-id>:role/<okta-role-name>
 ```

--- a/lib/okta.go
+++ b/lib/okta.go
@@ -24,8 +24,8 @@ import (
 )
 
 const (
-	OktaServerUs = "okta.com"
-	OktaServerEmea = "okta-emea.com"
+	OktaServerUs      = "okta.com"
+	OktaServerEmea    = "okta-emea.com"
 	OktaServerPreview = "oktapreview.com"
 	OktaServerDefault = OktaServerUs
 
@@ -61,7 +61,7 @@ type OktaCreds struct {
 	Organization string
 	Username     string
 	Password     string
-	Domain 		 string
+	Domain       string
 }
 
 func (c *OktaCreds) Validate(mfaDevice string) error {
@@ -80,12 +80,12 @@ func (c *OktaCreds) Validate(mfaDevice string) error {
 
 func getOktaDomain(region string) (string, error) {
 	switch region {
-		case "us":
-			return OktaServerUs, nil
-		case "emea":
-			return OktaServerEmea, nil
-		case "preview":
-			return OktaServerPreview, nil
+	case "us":
+		return OktaServerUs, nil
+	case "emea":
+		return OktaServerEmea, nil
+	case "preview":
+		return OktaServerPreview, nil
 	}
 	return "", fmt.Errorf("invalid region %s", region)
 }
@@ -126,14 +126,14 @@ func NewOktaClient(creds OktaCreds, oktaAwsSAMLUrl string, sessionCookie string,
 
 	return &OktaClient{
 		// Setting Organization for backwards compatibility
-		Organization:   	creds.Organization,
-		Username:       	creds.Username,
-		Password:       	creds.Password,
-		OktaAwsSAMLUrl: 	oktaAwsSAMLUrl,
-		CookieJar:      	jar,
-		BaseURL:        	base,
-		MFADevice:          mfaDevice,
-		Domain: 			domain,
+		Organization:   creds.Organization,
+		Username:       creds.Username,
+		Password:       creds.Password,
+		OktaAwsSAMLUrl: oktaAwsSAMLUrl,
+		CookieJar:      jar,
+		BaseURL:        base,
+		MFADevice:      mfaDevice,
+		Domain:         domain,
 	}, nil
 }
 
@@ -419,12 +419,12 @@ func (o *OktaClient) Get(method string, path string, data []byte, recv interface
 	var header http.Header
 	var client http.Client
 
- 	url, err := url.Parse(fmt.Sprintf(
- 		"%s/%s", o.BaseURL, path,
- 	))
- 	if err != nil {
- 		return err
- 	}
+	url, err := url.Parse(fmt.Sprintf(
+		"%s/%s", o.BaseURL, path,
+	))
+	if err != nil {
+		return err
+	}
 
 	if format == "json" {
 		header = http.Header{
@@ -483,6 +483,7 @@ type OktaProvider struct {
 	SessionDuration time.Duration
 	OktaAwsSAMLUrl  string
 	MFADevice       string
+	OktaSessionKey  string
 }
 
 func (p *OktaProvider) Retrieve() (sts.Credentials, string, error) {
@@ -500,7 +501,7 @@ func (p *OktaProvider) Retrieve() (sts.Credentials, string, error) {
 
 	// Check for stored session cookie
 	var sessionCookie string
-	cookieItem, err := p.Keyring.Get("okta-session-cookie")
+	cookieItem, err := p.Keyring.Get(p.OktaSessionKey)
 	if err == nil {
 		sessionCookie = string(cookieItem.Data)
 	}
@@ -516,7 +517,7 @@ func (p *OktaProvider) Retrieve() (sts.Credentials, string, error) {
 	}
 
 	newCookieItem := keyring.Item{
-		Key:   "okta-session-cookie",
+		Key:   p.OktaSessionKey,
 		Data:  []byte(newSessionCookie),
 		Label: "okta session cookie",
 		KeychainNotTrustApplication: false,

--- a/lib/okta.go
+++ b/lib/okta.go
@@ -503,7 +503,7 @@ func (p *OktaProvider) Retrieve() (sts.Credentials, string, error) {
 
 	// Check for stored session cookie
 	var sessionCookie string
-	cookieItem, err := p.Keyring.Get(p.OktaSessionKey)
+	cookieItem, err := p.Keyring.Get(p.OktaSessionCookieKey)
 	if err == nil {
 		sessionCookie = string(cookieItem.Data)
 	}
@@ -519,7 +519,7 @@ func (p *OktaProvider) Retrieve() (sts.Credentials, string, error) {
 	}
 
 	newCookieItem := keyring.Item{
-		Key:                         p.OktaSessionKey,
+		Key:                         p.OktaSessionCookieKey,
 		Data:                        []byte(newSessionCookie),
 		Label:                       "okta session cookie",
 		KeychainNotTrustApplication: false,

--- a/lib/okta.go
+++ b/lib/okta.go
@@ -483,7 +483,9 @@ type OktaProvider struct {
 	SessionDuration time.Duration
 	OktaAwsSAMLUrl  string
 	MFADevice       string
-	OktaSessionKey  string
+	// OktaSessionCookieKey represents the name of the session cookie
+	// to be stored in the keyring.
+	OktaSessionCookieKey string
 }
 
 func (p *OktaProvider) Retrieve() (sts.Credentials, string, error) {
@@ -517,9 +519,9 @@ func (p *OktaProvider) Retrieve() (sts.Credentials, string, error) {
 	}
 
 	newCookieItem := keyring.Item{
-		Key:   p.OktaSessionKey,
-		Data:  []byte(newSessionCookie),
-		Label: "okta session cookie",
+		Key:                         p.OktaSessionKey,
+		Data:                        []byte(newSessionCookie),
+		Label:                       "okta session cookie",
 		KeychainNotTrustApplication: false,
 	}
 

--- a/lib/provider.go
+++ b/lib/provider.go
@@ -146,13 +146,13 @@ func (p *Provider) getSamlURL(source string) (string, error) {
 	return "", errors.New("aws_saml_url missing from ~/.aws/config")
 }
 
-func (p *Provider) getOktaSessionKey(source string) string {
+func (p *Provider) getOktaSessionCookieKey(source string) string {
 	haystack := []string{p.profile, source, "okta"}
 	for _, profile := range haystack {
-		oktaSessionKey, ok := p.profiles[profile]["okta_session_key"]
+		oktaSessionCookieKey, ok := p.profiles[profile]["okta_session_cookie_key"]
 		if ok {
-			log.Debugf("Using okta_session_key from profile: %s", profile)
-			return oktaSessionKey
+			log.Debugf("Using okta_session_cookie_key from profile: %s", profile)
+			return oktaSessionCookieKey
 		}
 	}
 	return "okta-session-cookie"
@@ -164,7 +164,7 @@ func (p *Provider) getSamlSessionCreds() (sts.Credentials, error) {
 	if err != nil {
 		return sts.Credentials{}, err
 	}
-	oktaSessionKey := p.getOktaSessionKey(source)
+	oktaSessionCookieKey := p.getOktaSessionCookieKey(source)
 
 	profileARN, ok := p.profiles[source]["role_arn"]
 	if !ok {
@@ -172,12 +172,12 @@ func (p *Provider) getSamlSessionCreds() (sts.Credentials, error) {
 	}
 
 	provider := OktaProvider{
-		MFADevice:       p.ProviderOptions.MFADevice,
-		Keyring:         p.keyring,
-		ProfileARN:      profileARN,
-		SessionDuration: p.SessionDuration,
-		OktaAwsSAMLUrl:  oktaAwsSAMLUrl,
-		OktaSessionKey:  oktaSessionKey,
+		MFADevice:            p.ProviderOptions.MFADevice,
+		Keyring:              p.keyring,
+		ProfileARN:           profileARN,
+		SessionDuration:      p.SessionDuration,
+		OktaAwsSAMLUrl:       oktaAwsSAMLUrl,
+		OktaSessionCookieKey: oktaSessionCookieKey,
 	}
 
 	creds, oktaUsername, err := provider.Retrieve()


### PR DESCRIPTION
I have a specific case I want to solve here:

In addition to using aws-okta on the command line, I am using the aws-okta library for another Go application. This means that two separate applications need to access the same session stored in the keyring. The problem here is that on Mac OSX Keychain specifically, by default, items are only accessible by the application that created the Keychain.

To solve this problem, in this pull request, I am allowing the ability to configure the key to be stored in the keychain. Note: I haven't tested this on non Keychain backends, and am not sure of the implications of different keys with identical labels (works fine in Keychain).

I also made some lint fixes, which I am happy to revert.